### PR TITLE
Update settings and add release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,4 +3,4 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@v0.3.0
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download firmware artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware
+
+      - name: Create GitHub Release and upload artifacts
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.uf2
+            *.bin
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/config/corne.conf
+++ b/config/corne.conf
@@ -7,10 +7,6 @@ CONFIG_ZMK_BATTERY_REPORTING=y
 # Disable battery support to prevent waking up macOS from sleep
 CONFIG_BT_BAS=n  
 
-# Enable battery level of peripheral (requires additional software)
-CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY=y
-CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING=y
-
 # Power Management
 
 CONFIG_ZMK_IDLE_TIMEOUT=30000 

--- a/config/west.yml
+++ b/config/west.yml
@@ -7,7 +7,7 @@ manifest:
   projects:
     - name: zmk
       remote: zmkfirmware
-      revision: main
+      revision: v0.3.0
       import: app/west.yml
   self:
     path: config


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> CI/release automation changes can affect how firmware is built and published, and pinning to `v0.3.0` may change build outputs compared to tracking `main`.
> 
> **Overview**
> Pins firmware builds to ZMK `v0.3.0` by updating both the GitHub Actions reusable workflow reference and `west.yml` manifest revision from `main` to `v0.3.0`.
> 
> Adds a new tag-triggered `Release` workflow that runs the same build and then publishes a GitHub Release with generated notes, uploading `*.uf2`/`*.bin` artifacts.
> 
> Simplifies `config/corne.conf` by removing the split BLE central battery level proxy/fetching options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 467cbf48db4597819a6fa7df761939676162b4f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->